### PR TITLE
Fix error thrown by numpy in py3

### DIFF
--- a/examples/example_10_get_items_from_all_runs.py
+++ b/examples/example_10_get_items_from_all_runs.py
@@ -11,12 +11,12 @@ from pypet import pypetconstants
 
 def multiply(traj):
     """Sophisticated simulation of multiplication"""
-    z=traj.x*traj.y
-    traj.f_add_result('z',z, comment='I am the product of two reals!')
+    z=traj.x * traj.y
+    traj.f_add_result('z', z, comment='I am the product of two reals!')
 
 
 # Create an environment that handles running
-env = Environment(trajectory='Example10',filename='experiments/example_08/HDF5/example_10.hdf5',
+env = Environment(trajectory='Example10', filename='experiments/example_08/HDF5/example_10.hdf5',
                   file_title='Example10', log_folder='experiments/example_08/LOGS/',
                   comment='Another example!')
 
@@ -30,7 +30,7 @@ traj.f_add_parameter('y', 1, comment='I am the second dimension!')
 # Explore the parameters with a cartesian product:
 x_length = 15
 y_length = 15
-traj.f_explore(cartesian_product({'x':range(x_length), 'y':range(y_length)}))
+traj.f_explore(cartesian_product({'x': range(x_length), 'y': range(y_length)}))
 
 # Run the simulation
 env.f_run(multiply)
@@ -48,12 +48,12 @@ ys = traj.f_get('y').f_get_range()
 # the values.
 # Moreover, since `f_get_from_runs` returns an ordered dictionary
 # `values()` gives us all values already in the correct order of the runs.
-zs = traj.f_get_from_runs(name='z',fast_access=True).values()
+zs = traj.f_get_from_runs(name='z', fast_access=True).values()
 
 # Convert the lists to numpy 2D arrays
-x_mesh = np.reshape(np.array(xs),(x_length, y_length))
-y_mesh = np.reshape(np.array(ys),(x_length, y_length))
-z_mesh = np.reshape(np.array(zs),(x_length, y_length))
+x_mesh = np.reshape(np.array(xs), (x_length, y_length))
+y_mesh = np.reshape(np.array(ys), (x_length, y_length))
+z_mesh = np.reshape(np.array(list(zs)), (x_length, y_length))
 
 # Make fancy 3D plot
 fig=plt.figure()


### PR DESCRIPTION
Here's the error traceback:

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-37-2188dcd1b1a0> in <module>()
     52 x_mesh = np.reshape(np.array(xs),(x_length, y_length))
     53 y_mesh = np.reshape(np.array(ys),(x_length, y_length))
---> 54 z_mesh = np.reshape(np.array(zs),(x_length, y_length))
     55
     56 # Make fancy 3D plot

/home/att/Projects/hypergraph/py3/lib/python3.4/site-packages/numpy/core/fromnumeric.py in reshape(a, newshape, order)
    216     except AttributeError:
    217         return _wrapit(a, 'reshape', newshape, order=order)
--> 218     return reshape(newshape, order=order)
    219
    220

ValueError: total size of new array must be unchanged
```

What's the cause? `dictionary.values()` in python3 is a simple MappingView object
so np.array(zs) has dimention `1`. The simplest way of fixing this is
evaluating `values` as list.

I also improved formatting a bit in this file.
