### PR TITLE
allow output directories without trailing slash

### DIFF
--- a/pypet/storageservice.py
+++ b/pypet/storageservice.py
@@ -922,7 +922,10 @@ class HDF5StorageService(StorageService, HasLogger):
         elif filename is None:
             filename = 'Experiments.hdf5'
 
-        head, tail = os.path.split(filename)
+        if os.path.isdir(filename):
+            head, tail = (filename, '')
+        else:
+            head, tail = os.path.split(filename)
         if not head:
             # If the filename contains no path information,
             # we put it into the current working directory


### PR DESCRIPTION
When specifying a `filename` argument in the creation of an `Environment`, it is not possible to specify an existing environment except when the path ends with a slash. `os.path.split` takes the directory name as a filename and does not check if that directory exists.

This patch first checks if the directory exists and only uses `os.path.split` if the directory does not exist.