### PR TITLE
Update sphinx pngmath to imgmath

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autosummary','sphinx.ext.autodoc', 'sphinx.ext.doctest',
-              'sphinx.ext.coverage', 'sphinx.ext.viewcode', 'sphinx.ext.pngmath']
+              'sphinx.ext.coverage', 'sphinx.ext.viewcode', 'sphinx.ext.imgmath']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
pngmath was removed in Sphinx 1.8 and was succeeded by imgmath
https://www.sphinx-doc.org/en/stable/changes.html#features-removed