### PR TITLE
fix(py3.10): correct collections related imports

### DIFF
--- a/pypet/tests/unittests/utils_test.py
+++ b/pypet/tests/unittests/utils_test.py
@@ -3,7 +3,10 @@ __author__ = 'Robert Meyer'
 import time
 import sys
 import pickle
-from collections import Set, Sequence, Mapping
+try:
+    from collections import Set, Sequence, Mapping
+except ImportError:
+    from collections.abc import Set, Sequence, Mapping
 
 import pandas as pd
 import numpy as np

--- a/pypet/utils/comparisons.py
+++ b/pypet/utils/comparisons.py
@@ -2,7 +2,10 @@
 
 __author__ = 'Robert Meyer'
 
-from collections import Sequence, Mapping
+try:
+    from collections import Sequence, Mapping
+except ImportError:
+    from collections.abc import Sequence, Mapping
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
This was reported downstream for the Fedora package---the Python SIG are testing all Python packages with Py 3.10 now.

https://bugzilla.redhat.com/show_bug.cgi?id=1926610

The deprecated aliases to Collections Abstract Base Classes were removed from the collections module.
https://docs.python.org/3.10/whatsnew/changelog.html#python-3-10-0-alpha-5

https://bugs.python.org/issue37324