### PR TITLE
Replace ConfigParser.readfp() with ConfigParser.read_file()

### DIFF
--- a/pypet/pypetlogging.py
+++ b/pypet/pypetlogging.py
@@ -556,7 +556,7 @@ class LoggingManager(object):
 
         """
         parser = NoInterpolationParser()
-        parser.readfp(log_config)
+        parser.read_file(log_config)
 
         rename_func = lambda string: rename_log_file(string,
                                                      env_name=self.env_name,


### PR DESCRIPTION
The former is deprecated since Python 3.2, and was removed in Python 3.12.

https://docs.python.org/3.11/library/configparser.html#configparser.ConfigParser.readfp