### PR TITLE
Replace deprecated/removed unittest.TestCase method aliases

### DIFF
--- a/pypet/tests/unittests/brian2tests/brian2_parameter_test.py
+++ b/pypet/tests/unittests/brian2tests/brian2_parameter_test.py
@@ -250,7 +250,7 @@ class Brian2GetUnitFastTest(unittest.TestCase):
 
     def test_get_unit_fast(self):
         unit = get_unit_fast(42 * mV)
-        self.assertEquals(unit, 1000 * mV)
+        self.assertEqual(unit, 1000 * mV)
 
 
 if __name__ == '__main__':

--- a/pypet/tests/unittests/storage_test.py
+++ b/pypet/tests/unittests/storage_test.py
@@ -481,7 +481,7 @@ class StorageTest(TrajectoryComparator):
 
         store = pt.open_file(filename, mode='r+')
         table = store.root._f_get_child(traj.v_name).overview.parameters_overview
-        self.assertEquals(table.nrows, pypetconstants.HDF5_MAX_OVERVIEW_TABLE_LENGTH)
+        self.assertEqual(table.nrows, pypetconstants.HDF5_MAX_OVERVIEW_TABLE_LENGTH)
         store.close()
 
         for irun in range(pypetconstants.HDF5_MAX_OVERVIEW_TABLE_LENGTH,
@@ -492,7 +492,7 @@ class StorageTest(TrajectoryComparator):
 
         store = pt.open_file(filename, mode='r+')
         table = store.root._f_get_child(traj.v_name).overview.parameters_overview
-        self.assertEquals(table.nrows, pypetconstants.HDF5_MAX_OVERVIEW_TABLE_LENGTH)
+        self.assertEqual(table.nrows, pypetconstants.HDF5_MAX_OVERVIEW_TABLE_LENGTH)
         store.close()
 
         env.f_disable_logging()


### PR DESCRIPTION
The method alias `unittest.TestCase.assertEquals()` was deprecated in Python 3.2 and removed in Python 3.12. Replace it with `unittest.TestCase.assertEqual()`.

https://docs.python.org/3.11/library/unittest.html#deprecated-aliases