### PR TITLE
In examples, don’t pass keywords to Figure.gca()

### DIFF
--- a/examples/example_05_custom_parameter.py
+++ b/examples/example_05_custom_parameter.py
@@ -228,7 +228,7 @@ def main():
 
         #Plot fancy 3d plot
         fig = plt.figure(idx)
-        ax = fig.gca(projection='3d')
+        ax = fig.add_subplot(projection='3d')
         x = euler_data[:,0]
         y = euler_data[:,1]
         z = euler_data[:,2]

--- a/examples/example_06_parameter_presetting.py
+++ b/examples/example_06_parameter_presetting.py
@@ -146,7 +146,7 @@ def main():
 
         # Plot fancy 3d plot
         fig = plt.figure(idx)
-        ax = fig.gca(projection='3d')
+        ax = fig.add_subplot(projection='3d')
         x = euler_data[:,0]
         y = euler_data[:,1]
         z = euler_data[:,2]


### PR DESCRIPTION
This was deprecated in matplotlib 3.4.0:

https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.4.0.html#pyplot-gca-and-figure-gca-keyword-arguments

This does not work at all with current versions of matplotlib.

See also: https://stackoverflow.com/questions/67095247/gca-and-latest-version-of-matplotlib